### PR TITLE
Include nvidia*.ko dependencies in initramfs.cpio.gz too

### DIFF
--- a/debian/copy-modules.sh
+++ b/debian/copy-modules.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# copy selected kernel modules together with their dependencies
+# and print list of copied files to stdout
+#
+# usage: copy-modules.sh dir-with-lib-modules kernel-version output-dir module [module...]
+
+sysroot="$1"
+shift
+kver="$1"
+shift
+outdir="$1"
+shift
+set -e -x
+[ -n "$sysroot" ]
+[ -n "$kver" ]
+[ -n "$outdir" ]
+
+for mod in "$@"; do
+    modprobe --set-version="$kver" --dirname="$sysroot" --show-depends "$mod" | \
+    while read action path rest; do \
+        if [ "$action" = "insmod" ]; then
+            cp "$path" $outdir/
+            basename "$path"
+        fi
+    done
+done

--- a/debian/rules
+++ b/debian/rules
@@ -49,6 +49,7 @@ override_dh_auto_install:
 	mkdir -p $(OUTPUT_DIR)/usr/lib/yagna/lib/modules/$(DEB_VERSION_UPSTREAM)/updates/dkms
 	mv $(OUTPUT_DIR)/dkms/$(NVIDIA_MODULE)/$(NVIDIA_LATEST_VERSION)/$(DEB_VERSION_UPSTREAM)/x86_64/module/*.ko \
 		$(OUTPUT_DIR)/usr/lib/yagna/lib/modules/$(DEB_VERSION_UPSTREAM)/updates/dkms
+	depmod --basedir=$(OUTPUT_DIR)/usr/lib/yagna -a $(DEB_VERSION_UPSTREAM)
 
 	# Create symlink of built kernel into ya-runtime-vm runtime directory
 	mkdir -p $(OUTPUT_DIR)/usr/lib/yagna/plugins/ya-runtime-vm/runtime
@@ -75,7 +76,13 @@ override_dh_auto_install:
 	cp $(OUTPUT_DIR)/usr/lib/yagna/lib/modules/$(DEB_VERSION_UPSTREAM)/kernel/net/core/failover.ko $(OUTPUT_DIR)/modules
 	cp $(OUTPUT_DIR)/usr/lib/yagna/lib/modules/$(DEB_VERSION_UPSTREAM)/kernel/net/ipv6/ipv6.ko $(OUTPUT_DIR)/modules
 	cp $(OUTPUT_DIR)/usr/lib/yagna/lib/modules/$(DEB_VERSION_UPSTREAM)/kernel/net/packet/af_packet.ko $(OUTPUT_DIR)/modules
-	cp $(OUTPUT_DIR)/usr/lib/yagna/lib/modules/$(DEB_VERSION_UPSTREAM)/updates/dkms/nvidia*.ko $(OUTPUT_DIR)/modules
+	./debian/copy-modules.sh \
+		"$(OUTPUT_DIR)/usr/lib/yagna" \
+		"$(DEB_VERSION_UPSTREAM)" \
+		"$(OUTPUT_DIR)/modules" \
+		nvidia nvidia-uvm nvidia-drm \
+		| awk '!a[$$0]++' \
+		> $(OUTPUT_DIR)/modules/nvidia-modules.list
 	cd $(OUTPUT_DIR)/modules && find . | cpio --quiet -o -H newc -R 0:0 | gzip -9 > $(OUTPUT_DIR)/usr/lib/yagna/plugins/ya-runtime-vm/runtime/modules.cpio.gz
 
 	# Cleanup


### PR DESCRIPTION
Collect them dynamically using modprobe based on depmod output. In addition include (deduplicated) modules list in nvidia-modules.list.